### PR TITLE
add file .sql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '3307:3306'
     volumes:
       - my-db:/var/lib/mysql
+      - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - movie-networks
 volumes:

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,31 @@
+USE moviedb;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL,
+    email VARCHAR(45) NOT NULL,
+    password VARCHAR(30) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS content (
+    content_id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(50) NOT NULL,
+    release_date DATE,
+    genre VARCHAR(40),
+    content_type VARCHAR(40) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS reviews (
+    review_id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    content_id INT,
+    rating FLOAT,
+    comment TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    FOREIGN KEY (content_id) REFERENCES content(content_id)
+);
+


### PR DESCRIPTION
En este PR, se agregaron consultas SQL al archivo init.sql para inicializar y crear las tablas necesarias en la base de datos. Las tablas incluyen información sobre usuarios, contenido multimedia (películas, series, etc.) y revisiones asociadas a dicho contenido. Se incorporaron campos como created_at y updated_at para realizar un seguimiento del historial de revisiones.